### PR TITLE
chore: Changes name to route53-lego-k8s

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         with:
           name: tested-charm
-          path: .tox/**/route53-acme-operator_ubuntu-22.04-amd64.charm
+          path: .tox/**/route53-lego-k8s_ubuntu-22.04-amd64.charm
           retention-days: 5
       - name: Archive charmcraft logs
         if: failure()
@@ -83,7 +83,7 @@ jobs:
         with:
           name: tested-charm
       - name: Move charm in current directory
-        run: find ./ -name route53-acme-operator_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
+        run: find ./ -name route53-lego-k8s_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
       - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.4.0
         id: channel

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Route53 ACME Operator (K8s)
-[![CharmHub Badge](https://charmhub.io/route53-acme-operator/badge.svg)](https://charmhub.io/route53-acme-operator)
+# Route53 LEGO Operator (K8s)
+[![CharmHub Badge](https://charmhub.io/route53-lego-k8s/badge.svg)](https://charmhub.io/route53-lego-k8s)
 
 Let's Encrypt certificates in the Juju ecosystem for AWS route53 users.
 
@@ -13,7 +13,7 @@ charms that require Let's Encrypt certificates need to implement the requirer si
 Create a YAML configuration file with the following fields:
 
 ```yaml
-route53-acme-operator:
+route53-lego-k8s:
   email: <Account email address>
   aws_access_key_id: <AWS Access Key ID>
   aws_secret_access_key: <AWS Secret Access Key>
@@ -21,16 +21,16 @@ route53-acme-operator:
   aws_hosted_zone_id: <AWS Hosted Zone ID>
 ```
 
-Deploy `route53-acme-operator`:
+Deploy `route53-lego-k8s`:
 
 ```bash
-juju deploy route53-acme-operator --config <yaml config file>
+juju deploy route53-lego-k8s --config <yaml config file>
 ```
 
 Relate it to a `tls-certificates-requirer` charm:
 
 ```bash
-juju relate route53-acme-operator:certificates <tls-certificates-requirer>
+juju relate route53-lego-k8s:certificates <tls-certificates-requirer>
 ````
 
 ## Config

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""# acme_client Library.
+"""# lego_client Library.
 
 This library is designed to enable developers to easily create new charms for the ACME protocol.
 This library contains all the logic necessary to get certificates from an ACME server.
@@ -9,7 +9,7 @@ This library contains all the logic necessary to get certificates from an ACME s
 ## Getting Started
 To get started using the library, you need to fetch the library using `charmcraft`.
 ```shell
-charmcraft fetch-lib charms.acme_client_operator.v0.acme_client
+charmcraft fetch-lib charms.lego_client_operator.v0.lego_client
 ```
 You will also need to add the following library to the charm's `requirements.txt` file:
 - jsonschema
@@ -17,7 +17,7 @@ You will also need to add the following library to the charm's `requirements.txt
 
 Then, to use the library in an example charm, you can do the following:
 ```python
-from charms.acme_client_operator.v0.acme_client import AcmeClient
+from charms.lego_client_operator.v0.lego_client import AcmeClient
 from ops.main import main
 class ExampleAcmeCharm(AcmeClient):
     def __init__(self, *args):
@@ -78,14 +78,15 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from ops.pebble import ExecError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "b3c9913b68dc42b89dfd0e77ac57236d"
+LIBID = "d67f92a288e54ab68a6b6349e9b472c4"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 1
+
 
 logger = logging.getLogger(__name__)
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,19 +1,19 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: route53-acme-operator
+name: route53-lego-k8s
 
-display-name: Route53 ACME Operator
+display-name: Route53 LEGO (K8s)
 
 description: |
-  ACME operator implementing the provider side of the `tls-certificates`
+  LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server using route53 DNS.
 summary: |
-  ACME operator implementing the provider side of the `tls-certificates`
+  LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server using route53 DNS.
-website: https://charmhub.io/route53-acme-operator
-source: https://github.com/canonical/route53-acme-operator
-issues: https://github.com/canonical/route53-acme-operator/issues
+website: https://charmhub.io/route53-lego-k8s
+source: https://github.com/canonical/route53-lego-k8s-operator
+issues: https://github.com/canonical/route53-lego-k8s-operator/issues
 docs: https://discourse.charmhub.io/t/route53-acme-operator-docs-index/12514
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,14 +7,14 @@
 import logging
 from typing import Dict
 
-from charms.acme_client_operator.v0.acme_client import AcmeClient  # type: ignore[import]
+from charms.lego_base_k8s.v0.lego_client import AcmeClient  # type: ignore[import]
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus
 
 logger = logging.getLogger(__name__)
 
 
-class Route53AcmeOperatorCharm(AcmeClient):
+class Route53LegoK8s(AcmeClient):
     """Main class that is instantiated every time an event occurs."""
 
     REQUIRED_CONFIG = [
@@ -25,7 +25,7 @@ class Route53AcmeOperatorCharm(AcmeClient):
     ]
 
     def __init__(self, *args):
-        """Uses the acme_client library to manage events."""
+        """Uses the lego_client library to manage events."""
         super().__init__(*args, plugin="route53")
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
@@ -112,4 +112,4 @@ class Route53AcmeOperatorCharm(AcmeClient):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(Route53AcmeOperatorCharm)
+    main(Route53LegoK8s)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,12 +9,12 @@ from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 from parameterized import parameterized  # type: ignore[import]
 
-from charm import Route53AcmeOperatorCharm
+from charm import Route53LegoK8s
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.harness = Harness(Route53AcmeOperatorCharm)
+        self.harness = Harness(Route53LegoK8s)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 


### PR DESCRIPTION
# Description

This PR changes the charm name from `route52-acme-operator` to `route53-lego-k8s` in order to follow the charm naming convention.

## Reference
- https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit
- https://juju.is/docs/sdk/naming

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
