### PR TITLE
chore: Bumps artefact actions to v4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Run integration tests
         run: tox -e integration
       - name: Archive Tested Charm
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.ref_name == 'main' }}
         with:
           name: tested-charm
@@ -59,13 +59,13 @@ jobs:
           retention-days: 5
       - name: Archive charmcraft logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charmcraft-logs
           path: /home/runner/.local/state/charmcraft/log/*.log
       - name: Archive juju crashdump
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: juju-crashdump
           path: juju-crashdump-*.tar.xz
@@ -81,7 +81,7 @@ jobs:
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
       - name: Fetch Tested Charm
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tested-charm
       - name: Move charm in current directory


### PR DESCRIPTION
# Description
Bumps actions workflow to v4. This should remove the need for the following PR's which are failing because they have been pushed separately instead of combined:

- PR #29 
- PR #30 

There seems to be this intermittent issue with v4 that I experienced here. We may want to pause before merging this PR:
- https://github.com/actions/download-artifact/issues/249

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
