### PR TITLE
fix: Removes unnecessary codeowners file

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @canonical/telco


### PR DESCRIPTION
# Description

Removes unnecessary codeowners file with the wrong team. The good CODEOWNERS file already exists in this project's root directory.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
