### PR TITLE
chore: Removes documentation from README and link to docs on Charmhub instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 LEGO operator implementing the provider side of the 
 [`tls-certificates` interface](https://github.com/canonical/tls-certificates-interface) 
 to get signed certificates from the `Let's Encrypt` ACME server
-using [AMAZON ROUTE 53](https://go-acme.github.io/lego/dns/route53/) plugin and the DNS-01 challenge.
+using [Amazon Route 53](https://go-acme.github.io/lego/dns/route53/) plugin and the DNS-01 challenge.
 
 For more information including guides, integrations, configuration options, see [Route53 LEGO's Charmhub page](https://charmhub.io/route53-lego-k8s).
 

--- a/README.md
+++ b/README.md
@@ -1,59 +1,12 @@
 # Route53 LEGO Operator (K8s)
 [![CharmHub Badge](https://charmhub.io/route53-lego-k8s/badge.svg)](https://charmhub.io/route53-lego-k8s)
 
-Let's Encrypt certificates in the Juju ecosystem for AWS route53 users.
+LEGO operator implementing the provider side of the 
+[`tls-certificates` interface](https://github.com/canonical/tls-certificates-interface) 
+to get signed certificates from the `Let's Encrypt` ACME server
+using [AMAZON ROUTE 53](https://go-acme.github.io/lego/dns/route53/) plugin and the DNS-01 challenge.
 
-# Pre-requisites
-
-This charm is a provider of the [`tls-certificates-interface`](https://github.com/canonical/tls-certificates-interface), 
-charms that require Let's Encrypt certificates need to implement the requirer side.
-
-## Usage
-
-Create a YAML configuration file with the following fields:
-
-```yaml
-route53-lego-k8s:
-  email: <Account email address>
-  aws_access_key_id: <AWS Access Key ID>
-  aws_secret_access_key: <AWS Secret Access Key>
-  aws_region: <AWS Region>
-  aws_hosted_zone_id: <AWS Hosted Zone ID>
-```
-
-Deploy `route53-lego-k8s`:
-
-```bash
-juju deploy route53-lego-k8s --config <yaml config file>
-```
-
-Relate it to a `tls-certificates-requirer` charm:
-
-```bash
-juju relate route53-lego-k8s:certificates <tls-certificates-requirer>
-````
-
-## Config
-
-### Required configuration properties
-
-- email: Let's Encrypt email address
-- aws_access_key_id: AWS Access Key ID
-- aws_secret_access_key: AWS Secret Access Key
-- aws_region: AWS Region
-- aws_hosted_zone_id: AWS Hosted Zone ID
-
-### Optional configuration properties
-
-- server: Let's Encrypt server to use (default: `https://acme-v02.api.letsencrypt.org/directory`)
-- aws_max_retries: The number of maximum returns the service will use to make an individual API request (default: `5`)
-- aws_polling_interval: Time (in seconds) between DNS propagation checks in seconds (default: `15`)
-- aws_propagation_timeout: Maximum waiting time (in seconds) for DNS propagation in seconds (default: `3600`)
-- aws_ttl: The TTL of the TXT record used for the DNS challenge (default: `120`)
-
-## Relations
-
-- `certificates`: `tls-certificates-interface` provider
+For more information including guides, integrations, configuration options, see [Route53 LEGO's Charmhub page](https://charmhub.io/route53-lego-k8s).
 
 ## OCI Images
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   email:
     type: string
-    description: Account email address
+    description: Account email address to receive notifications from Let's Encrypt.
   server:
     type: string
     description: Certificate authority server

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,10 +7,12 @@ display-name: Route53 LEGO (K8s)
 
 description: |
   LEGO operator implementing the provider side of the `tls-certificates`
-  interface to get signed certificates from the `Let's Encrypt` ACME server using route53 DNS.
+  interface to get signed certificates from the `Let's Encrypt` ACME server
+  using AMAZON ROUTE 53 plugin and the DNS-01 challenge.
 summary: |
   LEGO operator implementing the provider side of the `tls-certificates`
-  interface to get signed certificates from the `Let's Encrypt` ACME server using route53 DNS.
+  interface to get signed certificates from the `Let's Encrypt` ACME server
+  using AMAZON ROUTE 53 plugin and the DNS-01 challenge.
 website: https://charmhub.io/route53-lego-k8s
 source: https://github.com/canonical/route53-lego-k8s-operator
 issues: https://github.com/canonical/route53-lego-k8s-operator/issues

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,11 +8,11 @@ display-name: Route53 LEGO (K8s)
 description: |
   LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server
-  using AMAZON ROUTE 53 plugin and the DNS-01 challenge.
+  using Amazon Route 53 plugin and the DNS-01 challenge.
 summary: |
   LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server
-  using AMAZON ROUTE 53 plugin and the DNS-01 challenge.
+  using Amazon Route 53 plugin and the DNS-01 challenge.
 website: https://charmhub.io/route53-lego-k8s
 source: https://github.com/canonical/route53-lego-k8s-operator
 issues: https://github.com/canonical/route53-lego-k8s-operator/issues


### PR DESCRIPTION
# Description

Improves the README, metadata and config files

Note for reviewers:
Please take a look at the enhanced docs in Charmhub:
- https://discourse.charmhub.io/t/route53-lego-operator-k8s-docs-index/12514

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
