### PR TITLE
fix: Uses type conversion instead of enforcing string config options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,18 +19,18 @@ options:
     type: string
     description: AWS Hosted Zone ID
   aws_max_retries:
-    type: string
-    default: "5"
+    type: int
+    default: 5
     description: The number of maximum returns the service will use to make an individual API request
   aws_polling_interval:
-    type: string
-    default: "15"
+    type: int
+    default: 15
     description: Time between DNS propagation checks in seconds
   aws_propagation_timeout:
-    type: string
-    default: "3600"
+    type: int
+    default: 3600
     description: Maximum waiting time for DNS propagation in seconds
   aws_ttl:
-    type: string
-    default: "120"
+    type: int
+    default: 120
     description: The TTL of the TXT record used for the DNS challenge

--- a/src/charm.py
+++ b/src/charm.py
@@ -52,22 +52,22 @@ class Route53LegoK8s(AcmeClient):
     @property
     def _aws_max_retries(self) -> str:
         """Returns aws max retries from config."""
-        return self.model.config.get("aws_max_retries")
+        return str(self.model.config.get("aws_max_retries"))
 
     @property
     def _aws_polling_interval(self) -> str:
         """Returns aws polling interval from config."""
-        return self.model.config.get("aws_polling_interval")
+        return str(self.model.config.get("aws_polling_interval"))
 
     @property
     def _aws_propagation_timeout(self) -> str:
         """Returns aws propagation timeout from config."""
-        return self.model.config.get("aws_propagation_timeout")
+        return str(self.model.config.get("aws_propagation_timeout"))
 
     @property
     def _aws_ttl(self) -> str:
         """Returns aws ttl from config."""
-        return self.model.config.get("aws_ttl")
+        return str(self.model.config.get("aws_ttl"))
 
     @property
     def _plugin_config(self) -> Dict[str, str]:


### PR DESCRIPTION
# Description

Uses type conversion for config options that are int instead of allowing the user to provide strings.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
