### PR TITLE
chore: remove black formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,6 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py38"]
-
 # Linting tools configuration
 [tool.ruff]
 line-length = 99

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,4 +1,3 @@
-black
 codespell
 coverage[toml]
 juju

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,6 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-black==24.2.0
-    # via -r test-requirements.in
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -23,8 +21,6 @@ cffi==1.16.0
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via black
 codespell==2.2.6
     # via -r test-requirements.in
 coverage[toml]==7.4.3
@@ -49,7 +45,7 @@ iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.22.1
+ipython==8.22.2
     # via ipdb
 jedi==0.19.1
     # via ipython
@@ -68,9 +64,7 @@ markupsafe==2.1.5
 matplotlib-inline==0.1.6
     # via ipython
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   typing-inspect
+    # via typing-inspect
 nodeenv==1.8.0
     # via pyright
 oauthlib==3.2.2
@@ -79,19 +73,14 @@ oauthlib==3.2.2
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   black
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.0
-    # via black
 pluggy==1.4.0
     # via pytest
 prompt-toolkit==3.0.43
@@ -137,7 +126,7 @@ pytest-asyncio==0.21.1
     # via pytest-operator
 pytest-operator==0.34.0
     # via -r test-requirements.in
-python-dateutil==2.9.0
+python-dateutil==2.9.0.post0
     # via kubernetes
 pytz==2024.1
     # via pyrfc3339

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ pass_env =
 [testenv:format]
 description = Apply coding style standards to code
 commands =
-    black {[vars]all_path}
     ruff --fix {[vars]all_path}
 
 [testenv:lint]
@@ -37,7 +36,6 @@ description = Check code against coding style standards
 commands =
     codespell {tox_root}
     ruff check {[vars]all_path}
-    black --check --diff {[vars]all_path}
 
 [testenv:static]
 description = Run static type checks


### PR DESCRIPTION
# Description

Remove black formatter

## Rationale

As we switched to Ruff, we use it for formatting as well.

## Reference

- https://github.com/astral-sh/ruff

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
